### PR TITLE
Conflicting URL with lang prefix

### DIFF
--- a/lib/localization-middleware.rb
+++ b/lib/localization-middleware.rb
@@ -35,7 +35,7 @@ module Localization
     alias_method :langs=, :languages=
 
     def locale_pattern
-      @locale_pattern ||= /\A(?:\/(#{langs.join('|')}))?(\/?.*|)/i
+      @locale_pattern ||= /\A(?:\/(#{langs.join('|')})(?=$|\/))?(\/?.*|)/i
     end
 
     def set_locale

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -2,6 +2,12 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
 class MiddlewareTest < Test::Unit::TestCase
 
+  def check_locale_from_path_and_expected_path(path, expected_locale, expected_path)
+    @middleware.instance_variable_set('@env', {'PATH_INFO' => path })
+    assert_equal @middleware.send(:locale_from_url, path), expected_locale
+    assert_equal @middleware.instance_variable_get('@env')['PATH_INFO'], expected_path
+  end
+
   def setup
     @middleware = Localization::Middleware.new nil, [:en,:ru]
   end
@@ -24,12 +30,28 @@ class MiddlewareTest < Test::Unit::TestCase
     assert_equal :ru, ::I18n.locale
 
     @middleware.send(:unset_locale)
-    assert_equal ::I18n.default_locale, ::I18n.locale
+    assert_equal ::I18n.locale, I18n.default_locale
   end
 
   def test_set_incorrect_locale
-    assert_equal nil, @middleware.send(:locale_from_url, '/test')
-    assert_equal nil, @middleware.send(:set_locale)
-    assert_equal ::I18n.default_locale, ::I18n.locale
+    assert_nil @middleware.send(:locale_from_url, '/test')
+    assert_nil @middleware.send(:set_locale)
+    assert_equal ::I18n.locale, I18n.default_locale
+  end
+
+  def test_correct_locale_with_path
+    check_locale_from_path_and_expected_path('/ru/test', 'ru', '/test')
+  end
+
+  def test_set_incorrect_locale_with_conflicting_path
+    check_locale_from_path_and_expected_path('/running', nil, '/running')
+  end
+
+  def test_set_incorrect_locale_with_nonconflicting_path
+    check_locale_from_path_and_expected_path('/test', nil, '/test')
+  end
+
+  def test_set_correct_locale_with_conflicting_path
+    check_locale_from_path_and_expected_path('/ru/running', 'ru', '/running')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,11 +2,6 @@ require 'rubygems'
 require 'test/unit'
 require 'capybara'
 require 'capybara/dsl'
-if RUBY_VERSION >= '1.9.0'
-  require "debugger"
-else
-  require 'ruby-debug'
-end 
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
There is problem with `local_path` pattern matching when path prefix is same as one of locales.

Now it matches `'ru'` locale for `'/running'` path (with extracted path `'nning'`).

It should match `nil` locale for `'/running'` path.
And `'ru'` locale for `'/ru/running'` path.
Both with extracted path `'/running'`
